### PR TITLE
Fix namespace name and service account typo

### DIFF
--- a/hcp-vault/static-secrets/README.md
+++ b/hcp-vault/static-secrets/README.md
@@ -3,7 +3,7 @@
 ## Configure k8s
 
 ```shell
-kubectl create ns app-sa
+kubectl create ns app
 kubectl create sa app-sa -n app
 kubectl create clusterrolebinding vault-client-auth-delegator \
   --clusterrole=system:auth-delegator \

--- a/hcp-vault/static-secrets/vault-auth-static.yaml
+++ b/hcp-vault/static-secrets/vault-auth-static.yaml
@@ -16,6 +16,6 @@ spec:
   # k8s vault auth config 
   kubernetes:
     role: role1
-    serviceAccount: app
+    serviceAccount: app-sa
     audiences:
       - vault


### PR DESCRIPTION
Fix namespace name and service account typo to correct _VaultClientFactory  Failed to get cacheKey from obj, err=VaultAuth.secrets.hashicorp.com "static-auth" not found_ error